### PR TITLE
cambio nombre endpoints plural

### DIFF
--- a/internal/net/http/routes/route_evento.go
+++ b/internal/net/http/routes/route_evento.go
@@ -7,8 +7,8 @@ import (
 
 func RutasEvento(app *fiber.App) {
 	//app.Post("/evento", handlers.CrearEvento)
-	app.Get("/evento", handlers.ListarEventos)
+	app.Get("/eventos", handlers.ListarEventos)
 	app.Get("/eventos/:id", handlers.ObtenerEventoPorId)
-	//app.Put("/evento/:id", handlers.ActualizarEvento)
-	//app.Delete("/evento/:id", handlers.EliminarEvento)
+	//app.Put("/eventos/:id", handlers.ActualizarEvento)
+	//app.Delete("/eventos/:id", handlers.EliminarEvento)
 }


### PR DESCRIPTION
cambio de nombre de endpoints para que coincidan
el primero lo dejé igual porque es creacion de evento es singular/cuando se implemente podria cambiarse de nombre

se puede borrar la rama despues del merge